### PR TITLE
perf: set inst values on prototype where possible

### DIFF
--- a/engine/cssparser.js
+++ b/engine/cssparser.js
@@ -122,9 +122,7 @@ export class CSSRule {
 
 class CSSRegularAtRule {
   static {
-    // For review: I've copied what was originally here, but should this rather
-    // be RuleType.RegularAt?
-    this.prototype.type = RuleType.NestedAt;
+    this.prototype.type = RuleType.RegularAt;
     this.prototype.atName = '';
     this.prototype.atCond = '';
   }

--- a/engine/cssparser.js
+++ b/engine/cssparser.js
@@ -38,7 +38,9 @@ export const CombinatorType = {
 const isspace = c => c === ' ' || c === '\n';
 
 export class CSSRule {
-  type = RuleType.None;
+  static {
+    this.prototype.type = RuleType.None;
+  }
   selectors = [];
   properties = {};
 
@@ -119,9 +121,13 @@ export class CSSRule {
 }
 
 class CSSRegularAtRule {
-  type = RuleType.NestedAt;
-  atName = '';
-  atCond = '';
+  static {
+    // For review: I've copied what was originally here, but should this rather
+    // be RuleType.RegularAt?
+    this.prototype.type = RuleType.NestedAt;
+    this.prototype.atName = '';
+    this.prototype.atCond = '';
+  }
 
   constructor(name, cond) {
     this.atName = name;
@@ -130,9 +136,11 @@ class CSSRegularAtRule {
 }
 
 class CSSNestedAtRule {
-  type = RuleType.NestedAt;
-  atName = '';
-  atCond = '';
+  static {
+    this.prototype.type = RuleType.NestedAt;
+    this.prototype.atName = '';
+    this.prototype.atCond = '';
+  }
   rules = [];
 
   constructor(name, cond) {
@@ -142,22 +150,25 @@ class CSSNestedAtRule {
 }
 
 export class CSSParser {
-  mainState = MainState.None;
-  stringState = StringState.None;
-  atState = AtState.None;
-  escaping = false;
+  static {
+    this.prototype.mainState = MainState.None;
+    this.prototype.stringState = StringState.None;
+    this.prototype.atState = AtState.None;
+    this.prototype.escaping = false;
+  
+    this.prototype.currentSelector = '';
 
-  currentSelector = '';
+    this.prototype.currentRule = null;
+    this.prototype.parentRule = null;
+  
+    this.prototype.currentProp = '';
+    this.prototype.currentValue = '';
+  
+    this.prototype.currentAtName = '';
+    this.prototype.currentAtCond = '';
+  }
 
   rules = [];
-  currentRule = null;
-  parentRule = null;
-
-  currentProp = '';
-  currentValue = '';
-
-  currentAtName = '';
-  currentAtCond = '';
 
   constructor(bailing = true) {
     if (bailing) {

--- a/engine/dom.js
+++ b/engine/dom.js
@@ -1,11 +1,14 @@
 export class Node {
-  tagName = '';
-  parent = null;
-  document = null;
+  static {
+    this.prototype.tagName = '';
+    this.prototype.parent = null;
+    this.prototype.document = null;
+    this.prototype.content = '';
+    this.prototype._classesCache = null;
+  }
+
   children = [];
   attrs = {};
-
-  content = '';
 
   constructor(tagName = '', document = null) {
     Object.assign(this, { tagName, document });

--- a/engine/htmlparser.js
+++ b/engine/htmlparser.js
@@ -38,20 +38,22 @@ const SELF_CLOSING_RULES = {
 };
 
 export class HTMLParser {
-  attrState = AttrState.None;
-  tagState = TagState.None;
-  stringState = StringState.None;
-  escaping = false;
-
-  currentAttrName = '';
-  currentAttrValue = '';
-
-  currentName = '';
+  static {
+    this.prototype.attrState = AttrState.None;
+    this.prototype.tagState = TagState.None;
+    this.prototype.stringState = StringState.None;
+    this.prototype.escaping = false;
+  
+    this.prototype.currentAttrName = '';
+    this.prototype.currentAttrValue = '';
+  
+    this.prototype.currentName = '';
+    this.prototype.currentNode = null;
+    this.prototype.textNode = null;
+  }
 
   document = new Document();
   parent = this.document;
-  currentNode = null;
-  textNode = null;
 
   constructor() {}
 

--- a/engine/layout.js
+++ b/engine/layout.js
@@ -70,7 +70,9 @@ const IN = 96; // px
 
 const byPtr = {};
 export class LayoutNode extends Node {
-  renderer = null;
+  static {
+    this.prototype.renderer = null;
+  }
 
   cache = {};
   constructor(node, renderer) {

--- a/engine/renderer.js
+++ b/engine/renderer.js
@@ -14,7 +14,10 @@ let cWidth = window.innerWidth;
 let cHeight = window.innerHeight;
 
 export class Renderer {
-  layout = null;
+  static {
+    this.prototype.layout = null;
+    this.prototype.lastRootPtr = 0;
+  }
 
   constructor() {
     this.canvas = document.createElement('canvas');
@@ -87,7 +90,6 @@ export class Renderer {
     };
   }
 
-  lastRootPtr = 0;
   update() {
     if (!this.layout) {
       requestAnimationFrame(this.update);


### PR DESCRIPTION
This one is a little speculative, but based on the idea (illustrated by [getify](https://www.reddit.com/r/javascript/comments/cphx7n/askjs_whats_the_status_of_class_methods_being/ewtumtb/)) that any work that can be done in the prototype once rather than on each instance creation should help.

We can't use this for assigning `[]` or `{}` (as in those cases we *do* want to create a instance each time), but it's good for any strings, numbers, and nulls.

I'm not sure what the go-to perf test to stress-test this is, but would be curious to know the results.